### PR TITLE
brcmfmac: Look for wifi firmware in the standard location

### DIFF
--- a/v5.4.18-backports/drivers/net/wireless/broadcom/brcm80211/brcmfmac/firmware.h
+++ b/v5.4.18-backports/drivers/net/wireless/broadcom/brcm80211/brcmfmac/firmware.h
@@ -34,11 +34,6 @@ static const char BRCM_ ## fw_name ## _FIRMWARE_BASENAME[] = \
 	BRCMF_FW_DEFAULT_PATH fw_base; \
 MODULE_FIRMWARE(BRCMF_FW_DEFAULT_PATH fw_base ".bin")
 
-#define CY_FW_DEF(fw_name, fw_base) \
-static const char BRCM_ ## fw_name ## _FIRMWARE_BASENAME[] = \
-	CY_FW_DEFAULT_PATH fw_base; \
-MODULE_FIRMWARE(CY_FW_DEFAULT_PATH fw_base ".bin")
-
 #define BRCMF_FW_ENTRY(chipid, mask, name) \
 	{ chipid, mask, BRCM_ ## name ## _FIRMWARE_BASENAME }
 


### PR DESCRIPTION
The Cypress backported brcmfmac driver looks for firmware called cypress/cyfmac43430-sdio.bin in /lib/firmware

Because we also use this same firmware for other boards but the in-tree brcmfmac driver on these other boards looks for the standard file brcm/brcmfmac43430-sdio.bin in /lib/firmware we make the backported brcmfmac driver behave like the newer upstream in-tree driver.

Signed-off-by: Florin Sarbu <florin@balena.io>